### PR TITLE
Changed the position of set -e in slurm script

### DIFF
--- a/sciLifeLab_utils/run_QC_analysis.py
+++ b/sciLifeLab_utils/run_QC_analysis.py
@@ -105,7 +105,6 @@ def submit_job(sample_config, global_config, output,  pipeline, env,
     slurm_handle = open(slurm_file, "w")
 
     slurm_handle.write("#! /bin/bash -l\n")
-    slurm_handle.write("set -e\n")
     slurm_handle.write("#SBATCH -A {}\n".format(project))
     slurm_handle.write("#SBATCH -o {}_{}.out\n".format(output,pipeline))
     slurm_handle.write("#SBATCH -e {}_{}.err\n".format(output,pipeline))
@@ -121,6 +120,7 @@ def submit_job(sample_config, global_config, output,  pipeline, env,
     if qos:
         slurm_handle.write("#SBATCH --qos={}".format(qos))
     slurm_handle.write("\n\n")
+    slurm_handle.write("set -e\n")
     slurm_handle.write("source activate {}\n".format(env))
     slurm_handle.write("module load bioinfo-tools\n")
     slurm_handle.write("module load bwa\n")

--- a/sciLifeLab_utils/run_assemblies.py
+++ b/sciLifeLab_utils/run_assemblies.py
@@ -104,7 +104,6 @@ def submit_job(sample_config, global_config, output,  pipeline, env,
         output,pipeline))
     slurm_handle = open(slurm_file, "w")
     slurm_handle.write("#! /bin/bash -l\n")
-    slurm_handle.write("set -e\n")
     slurm_handle.write("#SBATCH -A {}\n".format(project))
     slurm_handle.write("#SBATCH -o {}_{}.out\n".format(output,pipeline))
     slurm_handle.write("#SBATCH -e {}_{}.err\n".format(output,pipeline))
@@ -120,6 +119,7 @@ def submit_job(sample_config, global_config, output,  pipeline, env,
     if qos:
         slurm_handle.write("#SBATCH --qos={}".format(qos))
     slurm_handle.write("\n\n")
+    slurm_handle.write("set -e\n")
     slurm_handle.write("source activate {}\n".format(env))
     slurm_handle.write("module load bioinfo-tools\n")
     slurm_handle.write("module load soapdenovo/2.04-r240\n")

--- a/sciLifeLab_utils/run_validation.py
+++ b/sciLifeLab_utils/run_validation.py
@@ -85,7 +85,6 @@ def submit_job(sample_config, global_config, output,  pipeline, assembler,
         output,pipeline, assembler))
     slurm_handle = open(slurm_file, "w")
     slurm_handle.write("#! /bin/bash -l\n")
-    slurm_handle.write("set -e\n")
     slurm_handle.write("#SBATCH -A {}\n".format(project))
     slurm_handle.write("#SBATCH -o {}_{}_{}.out\n".format(
         output,pipeline,assembler))
@@ -104,6 +103,7 @@ def submit_job(sample_config, global_config, output,  pipeline, assembler,
     if qos:
         slurm_handle.write("#SBATCH --qos={}".format(qos))
     slurm_handle.write("\n\n")
+    slurm_handle.write("set -e\n")
     slurm_handle.write("source activate {}\n".format(env))
     slurm_handle.write("module load bioinfo-tools\n")
     slurm_handle.write("module load bwa\n")


### PR DESCRIPTION
Thanks to @senthil10 for catching this. Apparently slurm doesn't like having this before the `#SBATCH` declarations any longer.