### PR TITLE
Fixed samtools import command

### DIFF
--- a/nougat/__init__.py
+++ b/nougat/__init__.py
@@ -1,4 +1,4 @@
 """ Main NouGAT module
 """
 __import__('pkg_resources').declare_namespace(__name__)
-__version__='0.6.2'
+__version__='0.6.3'

--- a/sciLifeLab_utils/run_QC_analysis.py
+++ b/sciLifeLab_utils/run_QC_analysis.py
@@ -94,7 +94,7 @@ def main(args):
         if "abyss" in tools:
             extramodules.append("module load abyss/1.3.5\n")
         if "align" in tools:
-            extramodules.append("module load samtools/1.1\nmodule load bwa\n")
+            extramodules.append("module load samtools\nmodule load bwa\n")
         jobname = "{}_{}".format(sample_dir_name, pipeline)
         submit_job(sample_YAML_name, jobname, os.getcwd(), args, extramodules)
         os.chdir(projectFolder)

--- a/sciLifeLab_utils/run_validation.py
+++ b/sciLifeLab_utils/run_validation.py
@@ -76,7 +76,7 @@ def main(args):
             sample_YAML.close
 
             # Run the job
-            extramodules = ["module load samtools/1.1\nmodule load bwa\nmodule load BUSCO/1.1b1\n"]
+            extramodules = ["module load samtools\nmodule load bwa\nmodule load BUSCO/1.1b1\n"]
             jobname = "{}_{}_{}".format(sample_dir_name, pipeline, assembler)
             submit_job(sample_YAML_name, jobname, os.getcwd(), args, extramodules)
 


### PR DESCRIPTION
 `module load samtools`, although probably not needed for NouGAT, loads the same version of samtools on both clusters.