### PR TITLE
be able to collect fastq files for X directory structure as well

### DIFF
--- a/nougat/__init__.py
+++ b/nougat/__init__.py
@@ -1,4 +1,4 @@
 """ Main NouGAT module
 """
 __import__('pkg_resources').declare_namespace(__name__)
-__version__='0.6.3'
+__version__='0.6.4'

--- a/sciLifeLab_utils/run_QC_analysis.py
+++ b/sciLifeLab_utils/run_QC_analysis.py
@@ -43,20 +43,22 @@ def main(args):
         sample_YAML.write("libraries:\n")
 
         sample_data_dir = os.path.join(samples_data_dir,sample_dir_name)
-        # full path to flowcell
-        flowcells_dirs  = [os.path.join(sample_data_dir,flowcell) \
-                for flowcell in os.listdir(sample_data_dir) \
-                if os.path.isdir(os.path.join(sample_data_dir,flowcell))]
         
-        # to adapt the diretory structure in IRMA where it have one folder for lib prep.
-        # So shcek if the collected FC directories are really FC directory or a LIB prep dir
-        lib_prep_dirs = [fc for fc in flowcells_dirs if re.match(r'^[A-Z]$', os.path.basename(fc))]
+        # helper variables for collecting FCs
+        fc_pat, prep_pat = (r'^\d{6}_.*_?.*$', r'^[A-Z]$')
+        def _get_expected_dir(path, pat):
+            return [os.path.join(path, d) for d in os.listdir(path) if re.match(pat, d) \
+                    and os.path.isdir(os.path.join(path, d))]
+        
+        #collect FC directories            
+        flowcells_dirs  = _get_expected_dir(sample_data_dir, fc_pat)
+        
+        # to adapt the directory structure in IRMA where it have lib prep dir
+        lib_prep_dirs  = _get_expected_dir(sample_data_dir, prep_pat)
+        
+        # Check and collect the flowcells in the lib prep directory
         for prep_dir in lib_prep_dirs:
-            flowcells_dirs.extend([os.path.join(prep_dir,flowcell) \
-                for flowcell in os.listdir(prep_dir) \
-                if os.path.isdir(os.path.join(prep_dir,flowcell))])
-            if prep_dir in flowcells_dirs:
-                flowcells_dirs.remove(prep_dir)
+            flowcells_dirs.extend(_get_expected_dir(prep_dir, fc_pat))
             
         sample_files = []
         for flowcell in flowcells_dirs:

--- a/sciLifeLab_utils/run_QC_analysis.py
+++ b/sciLifeLab_utils/run_QC_analysis.py
@@ -47,7 +47,14 @@ def main(args):
         flowcells_dirs  = [os.path.join(sample_data_dir,flowcell) \
                 for flowcell in os.listdir(sample_data_dir) \
                 if os.path.isdir(os.path.join(sample_data_dir,flowcell))]
-
+        
+        # to adapt the diretory structure of X runs
+        checked_fc = [fc for fc in flowcells_dirs if re.match(r'^[A-Z]$', os.path.basename(fc))]
+        for fc_dir in checked_fc:
+            flowcells_dirs.extend([os.path.join(fc_dir,flowcell) \
+                for flowcell in os.listdir(fc_dir) \
+                if os.path.isdir(os.path.join(fc_dir,flowcell))])
+            
         sample_files = []
         for flowcell in flowcells_dirs:
 

--- a/sciLifeLab_utils/run_QC_analysis.py
+++ b/sciLifeLab_utils/run_QC_analysis.py
@@ -48,12 +48,15 @@ def main(args):
                 for flowcell in os.listdir(sample_data_dir) \
                 if os.path.isdir(os.path.join(sample_data_dir,flowcell))]
         
-        # to adapt the diretory structure of X runs
-        checked_fc = [fc for fc in flowcells_dirs if re.match(r'^[A-Z]$', os.path.basename(fc))]
-        for fc_dir in checked_fc:
-            flowcells_dirs.extend([os.path.join(fc_dir,flowcell) \
-                for flowcell in os.listdir(fc_dir) \
-                if os.path.isdir(os.path.join(fc_dir,flowcell))])
+        # to adapt the diretory structure in IRMA where it have one folder for lib prep.
+        # So shcek if the collected FC directories are really FC directory or a LIB prep dir
+        lib_prep_dirs = [fc for fc in flowcells_dirs if re.match(r'^[A-Z]$', os.path.basename(fc))]
+        for prep_dir in lib_prep_dirs:
+            flowcells_dirs.extend([os.path.join(prep_dir,flowcell) \
+                for flowcell in os.listdir(prep_dir) \
+                if os.path.isdir(os.path.join(prep_dir,flowcell))])
+            if prep_dir in flowcells_dirs:
+                flowcells_dirs.remove(prep_dir)
             
         sample_files = []
         for flowcell in flowcells_dirs:


### PR DESCRIPTION
Now only works if the sample folder structure is like the following

```
P3707_102/
└── 160527_AH7H2CBCXX
    ├── 1_160527_AH7H2CBCXX_P3707_102_1.fastq.gz
    ├── 1_160527_AH7H2CBCXX_P3707_102_2.fastq.gz
```

But `HiSeqX` projects have the following structure 

```
P5151_102/
└── A
    └── 160630_ST-E00198_0127_AHNCHLCCXX
        ├── P5151_102_S6_L004_R1_001.fastq.gz
        └── P5151_102_S6_L004_R2_001.fastq.gz
```

So it is not collecting any `fastq` files to process. 